### PR TITLE
UTF-8 decoding of language files

### DIFF
--- a/hyphenation.cabal
+++ b/hyphenation.cabal
@@ -72,7 +72,8 @@ library
     bytestring           >= 0.9     && < 0.11,
     containers           >= 0.3.0.0 && < 0.7,
     unordered-containers >= 0.2.1   && < 0.3,
-    zlib                 >= 0.5     && < 0.7
+    zlib                 >= 0.5     && < 0.7,
+    text
 
   if !impl(ghc>=7.11)
     build-depends: semigroups >= 0.16 && < 0.19


### PR DESCRIPTION
Hi, `hyphenation` doesn't work with non-latin languages (Russian for example) since UTF-8 language files aren't decoded. This PR fixes it.